### PR TITLE
Cambio en el sumador/restador para retrocompatibilidad

### DIFF
--- a/Alu5Bits.vhd
+++ b/Alu5Bits.vhd
@@ -8,9 +8,9 @@ entity Alu5Bits is
 	sel : in std_logic_vector(2 downto 0);
 	salida_final : out std_logic_vector(4 downto 0);
 	ov : out std_logic);
-	
+
 end Alu5Bits;
-	
+
 architecture structural of Alu5Bits is
 
 	signal sel_s, sel_log : std_logic_vector(1 downto 0);
@@ -28,21 +28,21 @@ architecture structural of Alu5Bits is
 			sel_b : out std_logic;
 			sel_log : out std_logic_vector(1 downto 0));
 	end component;
-	
+
 	component UnidadLogica
 		port(
 			a,b : in std_logic_vector(4 downto 0);
 			sel_log : in std_logic_vector(1 downto 0);
 			salida_log : out std_logic_vector(4 downto 0));
 	end component;
-	
+
 	component Multiplicador5Bits
 		port(
 			a,b : in std_logic_vector(4 downto 0);
 			salida_m : out std_logic_vector(4 downto 0);
 			ov_p : out std_logic); --Indica si hay acarreo
 	end component;
-	
+
 	component SumadorRestador5Bits
 		port (
 			a : in std_logic_vector(4 downto 0); --Las entradas son de 5 bits (4 downto 0)
@@ -51,14 +51,14 @@ architecture structural of Alu5Bits is
 			salida_sr : out std_logic_vector(4 downto 0); --Salida de 5 bits
 			ov_sr : out std_logic); --Acarreo de salida es 0 o 1
 	end component;
-	
+
 	component MuxSelB1
 		port (
 			b : in std_logic_vector(4 downto 0);
 			sel_b : in std_logic; --Indica si la salida sera b o 1
 			salida_muxb : out std_logic_vector(4 downto 0));
 	end component;
-	
+
 	component MuxOverflow
 		port (
 			ov_p : in std_logic; --Overflow del producto
@@ -66,7 +66,7 @@ architecture structural of Alu5Bits is
 			sel_ov : in std_logic; --Indica si mostrar el overflow
 			ov : out std_logic); --Indica si hay overflow
 	end component;
-	
+
 	component MuxSalida
 		port (
 			salida_log : in std_logic_vector(4 downto 0); --Salida de la unidad logica
@@ -75,7 +75,7 @@ architecture structural of Alu5Bits is
 			sel_s : in std_logic_vector(1 downto 0); --Variable de control
 			salida_final : out std_logic_vector(4 downto 0));
 	end component;
-	
+
 begin
 
 	i_UnidadControl : UnidadControl
@@ -86,21 +86,21 @@ begin
 			s_r => s_r,
 			sel_b => sel_b,
 			sel_log => sel_log);
-	 
+
 	i_UnidadLogica : UnidadLogica
 		port map(
 			a => a,
 			b => b,
 			sel_log => sel_log,
 			salida_log => salida_log);
-			
+
 	i_Multiplicador : Multiplicador5Bits
 		port map(
 			a => a,
 			b => b,
 			salida_m => salida_m,
 			ov_p => ov_p);
-			
+
 	i_SumadorRestador : SumadorRestador5Bits
 		port map(
 			a => a,
@@ -108,14 +108,14 @@ begin
 			s_r => s_r,
 			salida_sr => salida_sr,
 			ov_sr => ov_sr);
-			
+
 	i_MuxOverflow : MuxOverflow
 		port map(
 		ov_p => ov_p,
 		ov_sr => ov_sr,
 		sel_ov => sel_ov,
 		ov => ov);
-		
+
 	i_MuxSalida : MuxSalida
 		port map (
 			salida_log => salida_log,
@@ -123,11 +123,11 @@ begin
 			salida_sr => salida_sr,
 			sel_s => sel_s,
 			salida_final => salida_final);
-		
+
 	i_MuxSelB1 : MuxSelB1
 		port map (
 			b => b,
 			sel_b => sel_b,
 			salida_muxb => salida_muxb);
-			
+
 end structural;

--- a/BinA7Seg.vhd
+++ b/BinA7Seg.vhd
@@ -31,6 +31,5 @@ begin
 		"0110000" when "1110",
 		"0111000" when "1111",
 		"1111111" when others;
-		
+
 end behavioral;
-		

--- a/Multiplicador5Bits.vhd
+++ b/Multiplicador5Bits.vhd
@@ -8,18 +8,18 @@ entity Multiplicador5Bits is
 	a,b : in std_logic_vector(4 downto 0);
 	salida_m : out std_logic_vector(4 downto 0);
 	ov_p : out std_logic); --Indica si hay acarreo
-	
+
 end Multiplicador5Bits;
 
-architecture behavioral of Multiplicador5Bits is 
+architecture behavioral of Multiplicador5Bits is
 	signal producto : std_logic_vector(9 downto 0);
-begin 
+begin
 	producto <= std_logic_vector(signed(a)*signed(b));
 	salida_m <= producto(4 downto 0);
-	
+
 	--Para el overflow comprobamos si hay extension de signo
 	process(producto)
-		begin	
+		begin
 			if producto(9 downto 4) = "000000" then
 				ov_p <= '0';
 			elsif producto(9 downto 4) = "111111" then
@@ -28,5 +28,5 @@ begin
 				ov_p <= '1';
 			end if;
 	end process;
-	
+
 end behavioral;

--- a/MuxOverflow.vhd
+++ b/MuxOverflow.vhd
@@ -9,16 +9,16 @@ entity MuxOverflow is
 	ov_sr : in std_logic; --Overflow del sumador-restador
 	sel_ov : in std_logic; --Indica si mostrar el overflow
 	ov : out std_logic); --Indica si hay overflow
-	
+
 end MuxOverflow;
 
 architecture behavioral of MuxOverflow is
 begin
 
 	with sel_ov select
-		ov <= 
+		ov <=
 			ov_sr when '0',
 			ov_p when '1',
 			'-' when others;
-	
+
 end behavioral;

--- a/MuxSalida.vhd
+++ b/MuxSalida.vhd
@@ -10,17 +10,17 @@ entity MuxSalida is
 	salida_sr : in std_logic_vector(4 downto 0); --Salida del sumador-restador
 	sel_s : in std_logic_vector(1 downto 0); --Variable de control
 	salida_final : out std_logic_vector(4 downto 0));
-	
+
 end MuxSalida;
 
 architecture behavioral of MuxSalida is
 begin
 
 	with sel_s select
-		salida_final <= 
+		salida_final <=
 				salida_log when "00",
 				salida_m when "01",
 				salida_sr when "10",
 				"-----" when others;
-	
+
 end behavioral;

--- a/MuxSelB1.vhd
+++ b/MuxSelB1.vhd
@@ -8,7 +8,7 @@ entity MuxSelB1 is
 	b : in std_logic_vector(4 downto 0);
 	sel_b : in std_logic; --Indica si la salida sera b o 1
 	salida_muxb : out std_logic_vector(4 downto 0));
-	
+
 end MuxSelB1;
 
 architecture behavioral of MuxSelB1 is
@@ -21,10 +21,10 @@ begin
 		salida_muxb <= b;
 	elsif sel_b = '1' then
 		salida_muxb <= "00001";
-	else 
+	else
 		null;
 	end if;
-	
+
 end process;
 
 end behavioral;

--- a/Pract7.vhd
+++ b/Pract7.vhd
@@ -9,7 +9,7 @@ entity Pract7 is
 	ov : out std_logic;
 	d0 : out std_logic_vector(6 downto 0);
 	d1 : out std_logic_vector(6 downto 0));
-	
+
 end Pract7;
 
 architecture structural of Pract7 is
@@ -23,13 +23,13 @@ architecture structural of Pract7 is
 			salida_final : out std_logic_vector(4 downto 0);
 			ov : out std_logic);
 	end component;
-	
+
 	component BinA7Seg
 	port (
 		entrada : in std_logic_vector(3 downto 0);
 		salida : out std_logic_vector(6 downto 0));
 	end component;
-	
+
 begin
 
 	i_Alu5Bits : Alu5Bits
@@ -40,15 +40,15 @@ begin
 			salida_final => pw(4 downto 0),
 			ov => ov);
 			pw(7 downto 5) <= "000";
-		
+
 	i_BinA7Seg_0 : BinA7Seg
 		port map (
 			entrada => pw (3 downto 0),
 			salida => d0);
-	
+
 	i_BinA7Seg_1 : BinA7Seg
 		port map (
 			entrada => pw(7 downto 4),
 			salida => d1);
-	
+
 end structural;

--- a/SumadorRestador5Bits.vhd
+++ b/SumadorRestador5Bits.vhd
@@ -10,15 +10,15 @@ entity SumadorRestador5Bits is
 	s_r : in std_logic; --Indica si realizamos suma o resta
 	salida_sr : out std_logic_vector(4 downto 0); --Salida de 5 bits
 	ov_sr : out std_logic); --Acarreo de salida es 0 o 1
-	
+
 end SumadorRestador5Bits;
 
 architecture structural of SumadorRestador5Bits is
 
 	--Acarreos intermedios
-	
+
 	signal c : std_logic_vector(5 downto 0);
-	
+
 	component Sumador1Bit
 		port (
 			a_i : in std_logic; --Entradas a y b
@@ -31,11 +31,11 @@ architecture structural of SumadorRestador5Bits is
 begin
 		c(0) <= s_r; --Acarreo inicial es 0 en la suma y 1 en la resta
 		ov_sr <= (c(5) xor c(4)); --Acarreo final
-		
+
 		GenSum : for i in 0 to 4 generate
-		
+
 			i_Sumador1Bit : Sumador1Bit
-	
+
 			port map(
 				a_i => a(i),
 				b_i => (s_r xor b(i)),
@@ -43,5 +43,6 @@ begin
 				s_i => salida_sr(i),
 				c_i_mas_1 => c(i+1));
 		end generate GenSum;
-		
+
 end structural;
+--

--- a/SumadorRestador5Bits.vhd
+++ b/SumadorRestador5Bits.vhd
@@ -18,6 +18,7 @@ architecture structural of SumadorRestador5Bits is
 	--Acarreos intermedios
 
 	signal c : std_logic_vector(5 downto 0);
+   signal b_aux : std_logic_vector(4 downto 0);
 
 	component Sumador1Bit
 		port (
@@ -34,14 +35,15 @@ begin
 
 		GenSum : for i in 0 to 4 generate
 
-			i_Sumador1Bit : Sumador1Bit
+         b_aux(i) <= s_r xor b(i);
 
-			port map(
-				a_i => a(i),
-				b_i => (s_r xor b(i)),
-				c_i => c(i),
-				s_i => salida_sr(i),
-				c_i_mas_1 => c(i+1));
+			i_Sumador1Bit : Sumador1Bit
+			   port map(
+   				a_i => a(i),
+   				b_i => b_aux(i),
+   				c_i => c(i),
+   				s_i => salida_sr(i),
+   				c_i_mas_1 => c(i+1));
 		end generate GenSum;
 
 end structural;

--- a/UnidadControl.vhd
+++ b/UnidadControl.vhd
@@ -11,14 +11,14 @@ entity UnidadControl is
 	s_r : out std_logic;
 	sel_b : out std_logic;
 	sel_log : out std_logic_vector(1 downto 0));
-	
+
 end UnidadControl;
 
 architecture behavioral of UnidadControl is
 begin
 
 	with sel select
-		sel_s <= 
+		sel_s <=
 			"00" when "000", --A and B
 			"00" when "001", --A or B
 			"00" when "010", --A xor B
@@ -28,12 +28,11 @@ begin
 			"10" when "110", --A+1
 			"01" when "111", --AxB
 			"--" when others;
-			
-	--Ecuaciones obtenidas con Karnaugh		
+
+	--Ecuaciones obtenidas con Karnaugh
 	sel_ov <= sel(0) and sel(1);
 	s_r <= sel(0);
 	sel_b <= sel(1);
 	sel_log <= sel(1 downto 0);
-	
+
 end behavioral;
-	

--- a/UnidadLogica.vhd
+++ b/UnidadLogica.vhd
@@ -8,18 +8,18 @@ entity UnidadLogica is
 	a,b : in std_logic_vector(4 downto 0);
 	sel_log : in std_logic_vector(1 downto 0);
 	salida_log : out std_logic_vector(4 downto 0));
-	
+
 end UnidadLogica;
 
 architecture behavioral of UnidadLogica is
 begin
 
 		with sel_log select
-			salida_log <= 
+			salida_log <=
 				(a and b) when "00",
 				(a or b) when "01",
 				(a xor b) when "10",
 				(not a) when "11",
 				"00000" when others;
-				
+
 end behavioral;


### PR DESCRIPTION
Se ha reemplazado la operación lógica en la instancia del sumador de un bit por una variable auxiliar para retrocompatibilidad con versiones antiguas del lenguaje